### PR TITLE
Added support for scaled UIImages

### DIFF
--- a/Source Code/UIImage+FloodFill.m
+++ b/Source Code/UIImage+FloodFill.m
@@ -197,7 +197,7 @@
         
         CGImageRef newCGImage = CGBitmapContextCreateImage(context);
         
-        UIImage *result = [UIImage imageWithCGImage:newCGImage];
+        UIImage *result = [UIImage imageWithCGImage:newCGImage scale:[self scale] orientation:UIImageOrientationUp];
         
         CGImageRelease(newCGImage);
         


### PR DESCRIPTION
The UIImage being returned after a fill was not honouring the original scale of self. It now matches the scale.
