### PR TITLE
Fixes logic to get to y-1, y and y+1 byteIndex for antialiasing

### DIFF
--- a/Source Code/UIImage+FloodFill.m
+++ b/Source Code/UIImage+FloodFill.m
@@ -272,9 +272,9 @@
             }
             
             // left
-            if (x>0)
+            if (x>1 && y>0)
             {
-                byteIndex = (bytesPerRow * y) + (x-1) * bytesPerPixel;
+                byteIndex = bytesPerRow * (y-1) + (x-1) * bytesPerPixel;
                 color = getColorCode(byteIndex, imageData);
                 
                 if (!compareColor(ncolor, color, 0))
@@ -297,9 +297,9 @@
 #endif
                 }
             }
-            if (x<width)
+            if (x<width && y>0)
             {
-                byteIndex = (bytesPerRow * y) + (x+1) * bytesPerPixel;
+                byteIndex = bytesPerRow * (y-1) + (x+1) * bytesPerPixel;
                 color = getColorCode(byteIndex, imageData);
                 
                 if (!compareColor(ncolor, color, 0))
@@ -324,9 +324,9 @@
 
             }
             
-            if (y>0)
+            if (y>1)
             {
-                byteIndex = (bytesPerRow * (y-1)) + x * bytesPerPixel;
+                byteIndex = bytesPerRow * (y-2) + x * bytesPerPixel;
                 color = getColorCode(byteIndex, imageData);
                 
                 if (!compareColor(ncolor, color, 0))
@@ -351,7 +351,7 @@
             
             if (y<height)
             {
-                byteIndex = (bytesPerRow * (y+1)) + x * bytesPerPixel;
+                byteIndex = bytesPerRow * y + x * bytesPerPixel;
                 color = getColorCode(byteIndex, imageData);
                 
                 if (!compareColor(ncolor, color, 0))


### PR DESCRIPTION
Thanks for the great work on this project and for making it open source. In trying it out I bumped into some crashes in getColorCode similar to the one reported in issue #3 . The cause of the crash is byteIndex out of memory range of imageData. What's causing it seems to be a logic error in the way antialias calculates the byteIndex of y-1 and y+1.

If I understood it correctly, it is actually calculating a byteIndex row in excess. So, when it gets to y==height-1 it looks for height+1 instead of y==height position. This gives a byteIndex looking for a position in memory that is == (height \* width \* 4) + x \* bytesPerPixel. This is out of range so it crashes.

I made such changes and this issue seem to be solved. Let me know if this makes sense to you. Thanks again.
