### PR TITLE
Mem alloc calculation error

### DIFF
--- a/Source Code/UIImage+FloodFill.m
+++ b/Source Code/UIImage+FloodFill.m
@@ -41,11 +41,11 @@
         NSUInteger width = CGImageGetWidth(imageRef);
         NSUInteger height = CGImageGetHeight(imageRef);
         
-        unsigned char *imageData = malloc(height * width * 4);
-        
         NSUInteger bytesPerPixel = CGImageGetBitsPerPixel(imageRef) / 8;
         NSUInteger bytesPerRow = CGImageGetBytesPerRow(imageRef);
         NSUInteger bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+        
+        unsigned char *imageData = malloc(bytesPerRow * height);
         
         CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
         


### PR DESCRIPTION
Error: 'CGContextDrawImage' returns 'EXC_BAD_ACCESS' with some images/sizes.

Observation: Some images have a greater bytesPerRow than assumed (My case: resized image.)

Some instances, bytesPerRow is greater than assumed "width \* 4", so using "height \* width \* 4" would not allocate enough memory for the image.
(i.e my test has 300px width, 4 bytes per px, thus theoretical 1200 bytesPerRow, but CGImageGetBytesPerRow(imageRef) returns 1216.)

As we know the bytesPerRow from the lib, we should use this instead.
