### PR TITLE
Fixed startPoint value casting inconsistency

### DIFF
--- a/Source Code/UIImage+FloodFill.m
+++ b/Source Code/UIImage+FloodFill.m
@@ -61,7 +61,7 @@
         CGContextDrawImage(context, CGRectMake(0, 0, width, height), imageRef);
         
         //Get color at start point
-        unsigned int byteIndex = (bytesPerRow * startPoint.y) + startPoint.x * bytesPerPixel;
+        unsigned int byteIndex = (bytesPerRow * ((int)startPoint.y)) + ((int)startPoint.x) * bytesPerPixel;
         
         unsigned int ocolor = getColorCode(byteIndex, imageData);
         


### PR DESCRIPTION
as sugessted by @mristuccia in Issue #14 

Without this change, algorithm somethimes break first while a loop after second itteration and return only one point filled.
