### PR TITLE
Bitmap info fix for iOS 8

### DIFF
--- a/UIImage Scanline Floodfill/UIImage Scanline Floodfill/UIImage+FloodFill.m
+++ b/UIImage Scanline Floodfill/UIImage Scanline Floodfill/UIImage+FloodFill.m
@@ -53,6 +53,9 @@
         NSUInteger bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
         
         CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
+        if (kCGImageAlphaLast == (uint32_t)bitmapInfo || kCGImageAlphaFirst == (uint32_t)bitmapInfo) {
+            bitmapInfo = (uint32_t)kCGImageAlphaPremultipliedLast;
+        }
         
         CGContextRef context = CGBitmapContextCreate(imageData,
                                                      width,
@@ -60,7 +63,7 @@
                                                      bitsPerComponent,
                                                      bytesPerRow,
                                                      colorSpace,
-                                                     CGImageGetBitmapInfo(imageRef));
+                                                     bitmapInfo);
         CGColorSpaceRelease(colorSpace);
         
         CGContextDrawImage(context, CGRectMake(0, 0, width, height), imageRef);


### PR DESCRIPTION
I found bug when ran project on iOS 8 simulator

```
UIImage Scanline Floodfill[5511] <Error>: CGBitmapContextCreate: unsupported parameter combination: 8 integer bits/component; 32 bits/pixel; 3-component color space; kCGImageAlphaLast; 2560 bytes/row.
```

Break point on 'bitmapInfo' creation (line 56, UIImage+FloodFill.m) gives value:

```
(CGBitmapInfo) bitmapInfo = 3
```

or *kCGImageAlphaLast*.

and this is the reason for the error. 

https://developer.apple.com/library/mac/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB