### PR TITLE
BUGFIX: EXC_BAD_ACCESS during CGContextDrawImage

### DIFF
--- a/UIImage Scanline Floodfill/UIImage Scanline Floodfill/UIImage+FloodFill.m
+++ b/UIImage Scanline Floodfill/UIImage Scanline Floodfill/UIImage+FloodFill.m
@@ -49,7 +49,7 @@
         NSUInteger bytesPerRow = CGImageGetBytesPerRow(imageRef);
         NSUInteger bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
 
-        unsigned char *imageData = malloc(height * width * bytesPerPixel);
+        unsigned char *imageData = malloc(height * bytesPerRow);
       
         CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
       


### PR DESCRIPTION
Why it happened? In my case the image was 500 pixels width but:

  NSUInteger width = 500
  NSUInteger bytesPerPixel = 4
  NSUInteger bytesPerRow = 2016

Because the image took 2016 bytes per row instead of 2000 we need
to allocate more memory for the "imageData" array.